### PR TITLE
22 Add Kimarite CSV Raketask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-debug.log*
 
 # ignore simplecov
 /coverage
+
+.DS_Store

--- a/db/data/sumocity_kimarite_terms.csv
+++ b/db/data/sumocity_kimarite_terms.csv
@@ -1,0 +1,102 @@
+english_name,japanese_name,definition
+Rikishi,力士,A professional sumo wrestler. 
+Mawashi,廻し,The belt (loincloth) that the rikishi (or sumo wrestler) wears during training or in competition. 
+Dohyō,土俵,The ring in which sumo wrestling bouts are held.
+Honbasho,本場所,An official professional sumo tournament.
+Gyōji,行司,A referee in professional sumo wrestling in Japan.
+Shimpan,審判,The ring-side judges of a professional sumo bout.
+Kimarite,決まり手,Winning techniques in a sumo bout.
+Kihonwaza,基本技,"Basic techniques. These, with the exception of the rarely seen Abisetaoshi, are some of the most common kimarite in sumo."
+Abisetaoshi,浴びせ倒し,Forcing down the opponent on their back by leaning forward while in a grappling position (backward force down).
+Oshidashi,押し出し,"Pushing the opponent out of the ring without holding their mawashi or belt, nor fully extending his arms. Hand contact must be maintained through the push (front push out)."
+Oshitaoshi,押し倒し,Pushing the opponent down out of the ring (the opponent falls out of the ring instead of backing out) without holding their mawashi. Hand contact is maintained throughout the push (front push down).
+Tsukidashi,突き出し,Thrusting the opponent backwards out of the ring with one or a series of hand thrusts. The attacker does not have to maintain hand contact (front thrust out).
+Tsukitaoshi,突き倒し,Thrusting the opponent down out of the ring (the opponent falls over the edge) onto their back with a hard thrust or shove (front thrust down).
+Yorikiri,寄り切り,"Maintaining a grip on the opponent's mawashi, the opponent is forced backwards out of the ring (frontal force out)."
+Yoritaoshi,寄り倒し,"Maintaining a grip on the opponent's mawashi, the opponent is forced backwards out of the ring and collapses on their back from the force of the attack (front crush out)."
+Nagete,投げ手,Throwing techniques.
+Ipponzeoi,本背負い,"While moving backwards to the side, the opponent is pulled past the attacker and out of the ring by grabbing and pulling their arm with both hands (one-armed shoulder throw)."
+Kakenage,掛け投げ,"Lifting the opponent's thigh with one's leg, while grasping the opponent with both arms, and then throwing the off-balance opponent to the ground (hooking inner thigh throw)."
+Koshinage,腰投げ,"Bending over and pulling the opponent over the attacker's hip, then throwing the opponent to the ground on their back (hip throw)."
+Kotenage,小手投げ,"The attacker wraps their arm around the opponent's extended arm (差し手 - gripping arm), then throws the opponent to the ground without touching their mawashi. A common move (armlock throw)."
+Kubinage,首投げ,"The attacker wraps the opponent's head (or neck) in his arms, throwing him down (headlock throw)."
+Nichonage,二丁投げ,Extending the right (left) leg around the outside of the opponent's right (left) knee thereby sweeping both of his legs off the surface and throwing him down (body drop throw)
+Shitatedashinage,下手出し投げ,"The attacker extends their arm under the opponent's arm to grab the opponent's mawashi while dragging the opponent forwards and/or to the side, throwing them to the ground (pulling underarm throw)."
+Shitatenage,下手投げ,"The attacker extends their arm under the opponent's arm to grab the opponent's mawashi and turns sideways, pulling the opponent down and throwing them to the ground (underarm throw)."
+Sukuinage,掬い投げ,"The attacker extends their arm under the opponent's armpit and across their back while turning sideways, forcing the opponent forward and throwing him to the ground without touching the mawashi (beltless arm throw)."
+Tsukaminage,つかみ投げ,"The attacker grabs the opponent's mawashi and lifts his body off the surface, pulling them into the air past the attacker and throwing them down (lifting throw)."
+Uwatedashinage,上手出し投げ,The attacker extends their arm over the opponent's arm/back to grab the opponent's mawashi while pulling them forwards to the ground (pulling overarm throw).
+Uwatenage,上手投げ,The attacker extends their arm over the opponent's arm to grab the opponent's mawashi and throws the opponent to the ground while turning sideways (overarm throw).
+Yaguranage,櫓投げ,"With both wrestlers grasping each other's mawashi, pushing one's leg up under the opponent's groin, lifting them off the surface and then throwing them down on their side (inner thigh throw)."
+Kakete,掛け手,Leg tripping techniques.
+Ashitori,足取り,"Grabbing the opponent's leg and pulling upward with both hands, causing the opponent to fall over (leg pick)."
+Chongake,ちょん掛け,Hooking a heel under the opponent's opposite heel and forcing them to fall over backwards by pushing or twisting their arm (pulling heel hook).
+Kawazugake,河津掛け,"Wrapping one's leg around the opponent's leg of the opposite side, and tripping him backwards while grasping onto his upper body (hooking backward counter throw)."
+Kekaeshi,蹴返し,Kicking the inside of the opponent's foot. This is usually accompanied by a quick pull that causes the opponent to lose balance and fall (minor inner foot sweep).
+Ketaguri,蹴手繰り,"Directly after tachi-ai, kicking the opponent's legs to the outside and thrusting or twisting him down to the dohyō (pulling inside ankle sweep)."
+Kirikaeshi,切り返し,"The attacker places his leg behind the knee of the opponent, and while twisting the opponent sideways and backwards, sweeps him over the attacker's leg and throws him down (twisting backward knee trip)."
+Komatasukui,小股掬い,"When an opponent responds to being thrown and puts his leg out forward to balance himself, grabbing the underside of the thigh and lifting it up, throwing the opponent down (over thigh scooping body drop)."
+Kozumatori,小褄取り,"Lifting the opponent's ankle from the front, causing them to fall (ankle pick)."
+Mitokorozeme,三所攻め,"A triple attack. Wrapping one leg around the opponent's (inside leg trip), grabbing the other leg behind the thigh, and thrusting the head into the opponent's chest, the attacker pushes him up and off the surface, then throwing him down on his back (triple attack force out)."
+Nimaigeri,二枚蹴り,"Kicking an off-balance opponent on the outside of their standing leg's foot, then throwing him to the surface (ankle kicking twist down)."
+Omata,大股,"When the opponent escapes from a komatsukui by extending the other foot, the attacker switches to lift the opponent's other off-balance foot and throws him down (thigh scooping body drop)."
+Sotogake,外掛け,"Wrapping the calf around the opponent's calf from the outside and driving him over backwards (outside leg trip). The UFC light heavyweight champion Lyoto Machida, with a sumo background, has successfully used this multiple times in the course of his mixed martial arts career."
+Sotokomata,外小股,"Directly after a nage or hikkake is avoided by the opponent, grabbing the opponent's thigh from the outside, lifting it, and throwing them down on their back (over thigh scooping body drop)."
+Susoharai,裾払い,"Directly after a nage or hikkake is avoided by the opponent, driving the knee under the opponent's thigh and pulling them down to the surface (rear foot sweep)."
+Susotori,裾取り,"Directly after a nage is avoided by the opponent, grabbing the ankle of the opponent and pulling them down to the surface (ankle pick)."
+Tsumatori,褄取り,"As the opponent is losing their balance to the front (or is moving forward), grabbing the leg and pulling it back, thereby ensuring the opponent falls to the surface (rear toe pick)."
+Uchigake,内掛け,Wrapping the calf around the opponent's calf from the inside and forcing him down on his back (inside leg trip).
+Watashikomi,渡し込み,"While against the ring of the surface, the attacker grabs the underside of the opponent's thigh or knee with one hand and pushes with the other arm, thereby forcing the opponent out or down (thigh grabbing push down)."
+Hinerite,捻り手,Twist down techniques.
+Amiuchi,網打ち,"A throw with both arms pulling on the opponent's arm, causing the opponent to fall over forward (the fisherman's throw). It is so named because it resembles the traditional Japanese technique for casting fishing nets."
+Gasshohineri,合掌捻り,"With both hands clasped around the opponent's back, the opponent is twisted over sideways (clasped hand twist down)."
+Harimanage,波離間投げ,"Reaching over the opponent's back and grabbing hold of their mawashi, the opponent is pulled over in front or beside the attacker (backward belt throw)."
+Kainahineri,腕捻り,"Wrapping both arms around the opponent's extended arm and forcing him down to the dohyō by way of one's shoulder (two-handed arm twist down). (Similar to the tottari, but the body is positioned differently)"
+Katasukashi,肩透かし,"Wrapping two hands around the opponent's arm, both grasping the opponent's shoulder and forcing him down (under-shoulder swing down)."
+Kotehineri,小手捻り,"Twisting the opponent's arm down, causing a fall (arm lock twist down)."
+Kubihineri,首捻り,"Twisting the opponent's neck down, causing a fall (head twisting throw)."
+Makiotoshi,巻き落とし,"Reacting quickly to an opponent's actions, twisting the opponent's off-balance body down to the dohyō without grasping the mawashi (twist down)."
+Osakate,大逆手,"Taking the opponent's arm extended over one's arm and twisting the arm downward, while grabbing the opponent's body and throwing it in the same direction as the arm (backward twisting overarm throw)."
+Sabaori,鯖折り,"Grabbing the opponent's mawashi while pulling out and down, forcing the opponent's knees to the dohyō (forward force down)."
+Sakatottari,逆とったり,"To wrap one arm around the opponent's extended arm while grasping onto the opponent's wrist with the other hand, twisting and forcing the opponent down (arm bar throw counter or ""anti-tottari"")."
+Shitatehineri,下手捻り,"Extending the arm under the opponent's arm to grasp the mawashi, then pulling the mawashi down until the opponent falls or touches his knee to the dohyō (twisting underarm throw)."
+Sotomuso,外無双,Using the left (right) hand to grab onto the outside of the opponent's right (left) knee and twisting the opponent over one's left (right) knee (outer thigh propping twist down).
+Tokkurinage,徳利投げ,Grasping the opponent's neck or head with both hands and twisting him down to the dohyō (two handed head twist down).
+Tottari,とったり,Wrapping both arms around the opponent's extended arm and forcing him forward down to the dohyō (arm bar throw).
+Tsukiotoshi,突き落とし,"Twisting the opponent down to the dohyō by forcing the arms on the opponent's upper torso, off of his center of gravity (thrust down)."
+Uchimuso,内無双,Using the left (right) hand to grab onto the outside of the opponent's left (right) knee and twisting the opponent down (inner thigh propping twist down).
+Uwatehineri,上手捻り,"Extending the arm over the opponent's arm to grasp the mawashi, then pulling the mawashi down until the opponent falls or touches his knee to the dohyō (twisting overarm throw)."
+Zubuneri,ずぶねり,When the head is used to thrust an opponent down during a hineri (head pivot throw).
+Sorite,反り手,Backwards body drop techniques.
+Izori,居反り,"Diving under the charge of the opponent, the attacker grabs behind one or both of the opponent's knees, or their mawashi and pulls them up and over backwards (backwards body drop)."
+Kakezori,掛け反り,"Putting one's head under the opponent's extended arm and body, and forcing the opponent backwards over one's legs (hooking backwards body drop)."
+Shumokuzori,撞木反り,"In the same position as a tasukizori, but the wrestler throws himself backwards, thus ensuring that his opponent lands first under him (bell hammer drop). The name is derived from the similarity to the shape of Japanese bell hammers."
+Sototasukizori,外たすき反り,"With one arm around the opponents arm and one arm around the opponents leg, lifting the opponent and throwing him sideways and backwards (outer reverse backwards body drop)."
+Tasukizori,たすき反り,"With one arm around the opponents arm and one arm around the opponents leg, lifting the opponent perpendicular across the shoulders and throwing him down (kimono-string drop). The name refers to the cords used to tie the sleeves of the traditional Japanese kimono."
+Tsutaezori,伝え反り,Shifting the extended opponent's arm around and twisting the opponent behind one's back and down to the dohyō (underarm forward body drop).
+Tokushuwaza,特殊技,Special takedown techniques.
+Hatakikomi,叩き込み,"Slapping down the opponent's shoulder, back, or arm and forcing them to fall forwards touching the clay (slap down)."
+Hikiotoshi,引き落とし,"Pulling on the opponent's shoulder, arm, or mawashi and forcing them to fall forwards touching the clay (hand pull down)."
+Hikkake,引っ掛け,"While moving backwards to the side, the opponent is pulled past the attacker and out of the dohyō by grabbing and pulling their arm with both hands (arm grabbing force out)."
+Kimedashi,極め出し,Immobilizing the opponent's arms and shoulders with one's arms and forcing him out of the dohyō (arm barring force out).
+Kimetaoshi,極め倒し,Immobilizing the opponent's arms and shoulders with one's arms and forcing him down (arm barring force down).
+Okuridashi,送り出し,To push an off-balance opponent out of the dohyō from behind (rear push out).
+Okurigake,送り掛け,To trip an opponent's ankle up from behind (rear leg trip).
+Okurihikiotoshi,送り引き落とし,To pull an opponent down from behind (rear pull down).
+Okurinage,送り投げ,To throw an opponent from behind (rear throw down).
+Okuritaoshi,送り倒し,To knock down an opponent from behind (rear push down).
+Okuritsuridashi,送り吊り出し,To pick up the opponent by his mawashi from behind and throw him out of the dohyō (rear lift out).
+Okuritsuriotoshi,送り吊り落とし,To pick up the opponent by his mawashi from behind and throw him down on the dohyō (rear lifting body slam).
+Sokubiotoshi,素首落とし,Pushing the opponent's head down from the back of the neck (head chop down).
+Tsuridashi,吊り出し,"While wrestlers face each other, to pick up the opponent by his mawashi and deliver him outside of the dohyō (lift out)."
+Tsuriotoshi,吊り落とし,"While wrestlers face each other, to pick up the opponent by his mawashi and slam him onto the dohyō (lifting body slam)."
+Ushiromotare,後ろもたれ,"While the opponent is behind the wrestler, to back up and push him out of the dohyō (backward lean out)."
+Utchari,うっちゃり,"When near the edge of the dohyō, to bend oneself backwards and twist the opponent's body until he steps out of the dohyō (backward pivot throw)."
+Waridashi,割り出し,"To push one foot of the opponent out of the ring from the side, extending the arm across the opponent's body and using the leg to force him off balance (upper-arm force out)."
+Yobimodoshi,呼び戻し,"Reacting to the opponent's reaction to the attacker's inside pull, the attacker pulls them off by grabbing around them around the waist, before throwing them down (pulling body slam)."
+Hiwaza,非技,Non-techniques. There are five ways in which a wrestler can win without employing a technique.
+Fumidashi,踏み出し,The opponent accidentally takes a backward step outside the ring with no attack initiated against him (rear step out).
+Isamiashi,勇み足,"In the performance of a kimarite, the opponent inadvertently steps too far forward and places a foot outside the ring. (forward step out)."
+Koshikudake,腰砕け,The opponent falls over backwards without a technique being initiated against him. This usually happens because he has over-committed to an attack. (inadvertent collapse).
+Tsukihiza,つきひざ,The opponent stumbles and lands on one or both knees without any significant prior contact with the winning wrestler (knee touch down).
+Tsukite,つき手,The opponent stumbles and lands on one or both hands without any significant prior contact with the winning wrestler (hand touch down).

--- a/lib/tasks/import_terms.rake
+++ b/lib/tasks/import_terms.rake
@@ -1,10 +1,11 @@
 require 'nokogiri'
 require 'open-uri'
+require 'csv'
 
 desc "Import terms from internet"
   task :import_terms => [:environment] do
 
-    document = Nokogiri::HTML.parse(open('https://en.wikipedia.org/wiki/Glossary_of_sumo_terms')) 
+    document = Nokogiri::HTML.parse(open('https://en.wikipedia.org/wiki/Glossary_of_sumo_terms'))
 
     puts "Document Type: #{document.class}"
 
@@ -20,7 +21,7 @@ desc "Import terms from internet"
       n += 1
       term = Term.find_or_create_by(english_name: english_name, japanese_name: japanese_name)
       puts "#{name_text} saved! #{n}" if term.save
-    end 
+    end
 
     definitions = document.xpath("//dd")
 
@@ -34,4 +35,11 @@ desc "Import terms from internet"
       q += 1
     end
 
+    s = 0
+    csv_file = "db/data/sumocity_kimarite_terms.csv"
+    CSV.foreach(csv_file, :headers => true) do |row|
+      term = Term.find_or_create_by(english_name: row[0], japanese_name: row[1], definition: row[2])
+      puts "#{row[0]} found or imported #{s}"
+      s += 1
+    end
   end


### PR DESCRIPTION
# PR Documentation

## Fixes #22 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Add CSV import to the import_terms raketask to import Kimarite (winning move) terms to the Term table

## How Has This Been Tested?
- [ ] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [ ] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [ ] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes

## Other
- Rake task will need to be run on Heroku