### PR TITLE
26 Add random Term to index page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
   gem 'simplecov'
+  gem 'pry'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    coderay (1.1.2)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
     crass (1.0.6)
@@ -111,6 +112,9 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     pg (1.2.3)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.4)
     puma (4.3.3)
       nio4r (~> 2.0)
@@ -241,6 +245,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
+  pry
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.2)
   react-rails

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Welcome to SumoCity! SumoCity is designed to keep track of everything Sumo! Curr
 * Change into SumoCity project directory
 * Install dependencies: `bundle install`
 * Create database: `rails db:create`
-* Migrate databse: `rails db:migrate`
-* Run rake task to import data: `rake import_terms`
+* Migrate to development database: `rails db:migrate`
+* Run rake task to import data to development database: `rake import:terms`
 * Start server: `rails s`
 
 ## Testing

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -103,6 +103,10 @@ ul {
   padding: 2rem;
 }
 
+.heroText h3, h4 {
+  text-align: center;
+}
+
 .heroImage {
   display: grid;
   justify-items: center;

--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -1,4 +1,5 @@
 class IndexController < ApplicationController
   def index
+    @term = Term.all.sample(1).first
   end
 end

--- a/app/javascript/components/layout/homepage/HeroSumoWiki.js
+++ b/app/javascript/components/layout/homepage/HeroSumoWiki.js
@@ -1,20 +1,29 @@
 import React from "react"
+import PropTypes from "prop-types"
 
 class HeroSumoWiki extends React.Component {
   render() {
     return (
-      <div className="hero" id="heroSumoWiki">
-        <section className="heroText">
-          <h1>Learn More About Everything Sumo</h1>
-          <p>Use our Sumo Wiki to learn more about the rules, history, and vocab of Sumo.</p>
-        </section>
-        <section className="heroText">
-          <h1>Word of the Day</h1>
-          <p>Oshidashi: A frontal push out where the offensive wrestler pushes out their opponent maintaining hand contact at all times.</p>
-        </section>
-      </div>
+      <React.Fragment>
+        <div className="hero" id="heroSumoWiki">
+          <section className="heroText">
+            <h1>Learn More About Everything Sumo</h1>
+            <p>Use our Sumo Wiki to learn more about the rules, history, and vocab of Sumo.</p>
+          </section>
+          <section className="heroText">
+            <h1>Featured Term</h1>
+            <h3>{this.props.term.english_name}</h3>
+            <h4>{this.props.term.japanese_name}</h4>
+            <p>{this.props.term.definition}</p>
+          </section>
+        </div>
+      </React.Fragment>
     )
   }
 }
+
+HeroSumoWiki.propTypes = {
+  term: PropTypes.string
+};
 
 export default HeroSumoWiki

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -1,2 +1,2 @@
 <%= react_component 'layout/homepage/HeroStableExplorer' %>
-<%= react_component 'layout/homepage/HeroSumoWiki' %>
+<%= react_component 'layout/homepage/HeroSumoWiki', { term: @term } %>

--- a/lib/tasks/import_terms.rake
+++ b/lib/tasks/import_terms.rake
@@ -2,15 +2,13 @@ require 'nokogiri'
 require 'open-uri'
 require 'csv'
 
-desc "Import terms from internet"
-  task :import_terms => [:environment] do
-
+desc "Import terms from internet and CSV"
+namespace :import do
+  task :terms => [:environment] do
     document = Nokogiri::HTML.parse(open('https://en.wikipedia.org/wiki/Glossary_of_sumo_terms'))
-
     puts "Document Type: #{document.class}"
 
     names = document.xpath("//dt")
-
     n = 1
     names.each do |name|
       name_text = name.text
@@ -24,7 +22,6 @@ desc "Import terms from internet"
     end
 
     definitions = document.xpath("//dd")
-
     q = 1
     definitions.each do |definition|
       puts "#{definition.text} #{q}"
@@ -43,3 +40,45 @@ desc "Import terms from internet"
       s += 1
     end
   end
+
+  desc "Import data from internet and CSV"
+  task :terms_test => [:environment] do
+    Rails.env = 'test'
+    Rake::Task["db:seed"].invoke
+
+    document = Nokogiri::HTML.parse(open('https://en.wikipedia.org/wiki/Glossary_of_sumo_terms'))
+    puts "Document Type: #{document.class}"
+
+    names = document.xpath("//dt")
+    n = 1
+    names.each do |name|
+      name_text = name.text
+      puts "#{name_text} #{n}"
+      split_name = name_text.split(" (")
+      english_name = split_name[0]
+      japanese_name = split_name[1]
+      n += 1
+      term = Term.find_or_create_by(english_name: english_name, japanese_name: japanese_name)
+      puts "#{name_text} saved! #{n}" if term.save
+    end
+
+    definitions = document.xpath("//dd")
+    q = 1
+    definitions.each do |definition|
+      puts "#{definition.text} #{q}"
+      definition = definition.text
+      term = Term.find(q)
+      term.update(definition: definition)
+      puts "#{definition} saved! #{q}" if term.save
+      q += 1
+    end
+
+    s = 0
+    csv_file = "db/data/sumocity_kimarite_terms.csv"
+    CSV.foreach(csv_file, :headers => true) do |row|
+      term = Term.find_or_create_by(english_name: row[0], japanese_name: row[1], definition: row[2])
+      puts "#{row[0]} found or imported #{s}"
+      s += 1
+    end
+  end
+end

--- a/spec/features/index/index_spec.rb
+++ b/spec/features/index/index_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 describe "React homepage testing", :type => :feature, js: true do
   it 'can check the Homepage for content' do
+    @term = Term.create!(english_name: "Kimetaoshi", japanese_name: "極め倒し", definition: "Immobilizing the opponent's arms and shoulders with one's arms and forcing him down (arm barring force down).")
+
     visit('/')
     expect(page.title).to have_content("SumoCity")
 
@@ -16,7 +18,10 @@ describe "React homepage testing", :type => :feature, js: true do
     within "#heroSumoWiki" do
       expect(page).to have_content("Learn More About Everything Sumo")  
       expect(page).to have_content("Use our Sumo Wiki to learn more about the rules, history, and vocab of Sumo.")  
-      expect(page).to have_content("Word of the Day")
+      expect(page).to have_content("Featured Term")
+      expect(page).to have_content(@term.english_name)
+      expect(page).to have_content(@term.japanese_name)
+      expect(page).to have_content(@term.definition)
     end
 
     # Make sure About component content is not being rendered


### PR DESCRIPTION
# PR Documentation

## Fixes #26 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes
- Add a random Featured Term to index page
  - Add ActiveRecord query for a random Term resource to index method in index controller
  - Add tests for Featured Term text on index page

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [ ] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [x] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes

## Other
- Add shoulda matchers to check model validations!