### PR TITLE
37 Remove Travis Test Spec

### DIFF
--- a/spec/travis_test_spec.rb
+++ b/spec/travis_test_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-describe "Test" do
-  it "can run on Travis.ci" do
-    expect(2+2).to eq(4)
-  end
-end


### PR DESCRIPTION
# PR Documentation

## Fixes #37 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Remove the travis_test_spec since it is no longer needed now that the react testing has been configured properly using Selenium.

## How Has This Been Tested?
- [ ] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [ ] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [ ] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [ ] :100: New and existing unit tests pass locally with my changes

## Other