### PR TITLE
29 Add shoulda-matchers gem and Term model validations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,9 +51,9 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-# React tests
 group :test do
   gem 'capybara'
   gem 'selenium-webdriver'
   gem 'webdrivers'
+  gem 'shoulda-matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    shoulda-matchers (4.3.0)
+      activesupport (>= 4.2.0)
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -252,6 +254,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (>= 6)
   selenium-webdriver
+  shoulda-matchers
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The Capybara javascript driver has been set as Chrome with Selenium instead of R
 - headless chromium webdriver
 - Webpacker
 - Simplecov
+- shoulda-matchers
 
 ### Database Management
 - Postgresql

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -1,10 +1,15 @@
 class Term < ApplicationRecord
-
   before_validation :format_name
 
-  def format_name
-    self.english_name = self.english_name.capitalize
-    self.japanese_name = self.japanese_name.gsub(/[()]/, "")
-  end
+  validates_presence_of :english_name, :japanese_name, :definition
+  
+  private 
 
+    def format_name
+      if english_name.present? || japanese_name.present? || definition.present?
+        self.english_name = self.english_name.capitalize
+        self.japanese_name = self.japanese_name.gsub(/[()]/, "")
+        self.definition = self.definition.capitalize
+      end
+    end
 end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Term do
+  describe 'validations' do
+    it { should validate_presence_of(:english_name) }
+    it { should validate_presence_of(:japanese_name) }
+    it { should validate_presence_of(:definition) }
+  end
+
+  describe "before_action (capitalize and gsub parenthesis)" do
+    it 'should update names for a new record' do
+      @term = Term.new(english_name: 'kimetaoshi', japanese_name: '(極め倒し)', definition: "immobilizing the opponent's...")
+      @term.valid?
+      expect(@term.english_name).to  eq('Kimetaoshi') # Name has been capitalized
+      expect(@term.japanese_name).to  eq('極め倒し') # Parenthesis have been removed
+      expect(@term.definition).to  eq("Immobilizing the opponent's...") # Definition has been capitalized
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,3 +78,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
# PR Documentation

## Fixes #29 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes
- Add shoulda-matchers gem for model validations and testing
- Add Term model validations
- Update Term before_validation method to be a private method for security purposes
- Add if statement to before_validation method to work with validations

## How Has This Been Tested?
- [ ] :black_square_button: Integration testing
- [x] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [x] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes

## Other
- All the checklist checkboxes are checkmarked! The if statement in the before action seems strange but it was the official fix recommended by the shoulda-matchers gem issues in [this post](https://github.com/thoughtbot/shoulda-matchers/issues/734).