### PR TITLE
48 Correct HeroSumoWiki propType

### DIFF
--- a/app/javascript/components/layout/homepage/HeroSumoWiki.js
+++ b/app/javascript/components/layout/homepage/HeroSumoWiki.js
@@ -23,7 +23,7 @@ class HeroSumoWiki extends React.Component {
 }
 
 HeroSumoWiki.propTypes = {
-  term: PropTypes.string
+  term: PropTypes.object
 };
 
 export default HeroSumoWiki


### PR DESCRIPTION
# PR Documentation

## Fixes #48 

## Type of change
- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Correct heroSumoWiki component proptype
  - The heroSumoWIki component propType was incorrectly set as `string` instead of `object`. 
  - The component rendered correctly but produced a warning in the chrome dev tools.


## How Has This Been Tested?
- [ ] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [ ] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [ ] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes

## Other
- I wonder is there is a better way to test React propTypes other than the dev console? It might not be that easy with the current React-Rails setup...