### PR TITLE
31 Add SumoWiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,5 @@ These deprecation warnings can be silenced by appending the `RUBYOPT='-W:no-depr
 
  ## Contributions
 Interested in contributiong to SumoCity? Go ahead and open a PR!
+
+###### BabsLabs Software

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -37,9 +37,9 @@ html, body {
   margin: 0;
 }
 
+/* body wrapper - located in application.html.erb */
 .wrapper {
   min-height: 100%;
-
   /* Equal to height of footer */
   /* But also accounting for potential margin-bottom of last child */
   margin-bottom: -50px;
@@ -52,6 +52,8 @@ a {
 ul {
   list-style: none;
 }
+
+/* Nav bar */
 
 .navbar {
   display: flex;
@@ -90,10 +92,14 @@ ul {
   font-size: 2rem;
 }
 
+/* About page */
+
 .about {
   padding: 2rem;
   text-align: center;
 }
+
+/* Index page */
 
 .hero {
   display: grid;
@@ -131,6 +137,7 @@ ul {
   background-color: var(--light-color-two);
 }
 
+/* Footer */
 .push {
   height: 50px;
 }
@@ -148,4 +155,16 @@ ul {
 #babslabs-logo {
   height: 45px;
   padding-left: 10px;
+}
+
+/* SumoWiki (/terms) */
+.term {
+  margin: 25px 50px;
+}
+
+/* banners */
+.banner {
+  padding: 25px;
+  text-align: center;
+  background-color: var(--light-color-two);
 }

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,0 +1,5 @@
+class TermsController < ApplicationController
+  def index
+    @terms = Term.order(:english_name)
+  end
+end

--- a/app/javascript/components/layout/Banner.js
+++ b/app/javascript/components/layout/Banner.js
@@ -1,0 +1,18 @@
+import React from "react"
+import PropTypes from "prop-types"
+class Banner extends React.Component {
+  render () {
+    return (
+      <React.Fragment>
+        <div className="banner">
+          <h1>{this.props.text}</h1>
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+
+Banner.propTypes = {
+  text: PropTypes.string
+};
+export default Banner

--- a/app/javascript/components/layout/Navbar.js
+++ b/app/javascript/components/layout/Navbar.js
@@ -14,6 +14,9 @@ class Navbar extends React.Component {
             <li>
               <a href='/about'>About</a>
             </li>
+            <li>
+              <a href='/terms'>Wiki</a>
+            </li>
           </ul>
         </nav>
     )

--- a/app/javascript/components/layout/homepage/HeroSumoWiki.js
+++ b/app/javascript/components/layout/homepage/HeroSumoWiki.js
@@ -8,7 +8,7 @@ class HeroSumoWiki extends React.Component {
         <div className="hero" id="heroSumoWiki">
           <section className="heroText">
             <h1>Learn More About Everything Sumo</h1>
-            <p>Use our Sumo Wiki to learn more about the rules, history, and vocab of Sumo.</p>
+            <p>Use the <a href="/terms">SumoWiki</a> to learn more about the rules, history, and vocabulary of Sumo.</p>
           </section>
           <section className="heroText">
             <h1>Featured Term</h1>

--- a/app/javascript/components/layout/wiki/Term.js
+++ b/app/javascript/components/layout/wiki/Term.js
@@ -1,0 +1,17 @@
+import React from "react"
+import PropTypes from "prop-types"
+class Term extends React.Component {
+  render () {
+    return (
+        <div id={ `term-${this.props.term.id}` } className="term">
+          <h3>{ this.props.term.english_name } { this.props.term.japanese_name }</h3>
+          <p>{ this.props.term.definition }</p >
+        </div>
+    );
+  }
+}
+
+Term.propTypes = {
+  term: PropTypes.object
+};
+export default Term

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -1,15 +1,14 @@
 class Term < ApplicationRecord
   before_validation :format_name
 
-  validates_presence_of :english_name, :japanese_name, :definition
+  validates_presence_of(:english_name, :japanese_name, on: [:create, :update])
+  validates_presence_of(:english_name, :japanese_name, :definition, on: :update)
   
   private 
 
     def format_name
-      if english_name.present? || japanese_name.present? || definition.present?
-        self.english_name = self.english_name.capitalize
-        self.japanese_name = self.japanese_name.gsub(/[()]/, "")
-        self.definition = self.definition.capitalize
-      end
+        self.english_name = self.english_name.lstrip.capitalize if english_name.present?
+        self.japanese_name = self.japanese_name.gsub(/[()]/, "") if japanese_name.present?
+        self.definition = self.definition.lstrip.capitalize if definition.present?
     end
 end

--- a/app/views/terms/index.html.erb
+++ b/app/views/terms/index.html.erb
@@ -1,0 +1,4 @@
+<%= react_component 'layout/Banner', { text: "SumoWiki" } %>
+<% @terms.each do |term| %>
+  <%= react_component 'layout/wiki/Term', { term: term } %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Rails.application.routes.draw do
   root 'index#index'
   
   get '/about', to: 'about#index'
+  get '/terms', to: 'terms#index'
 
 end

--- a/lib/tasks/import_terms.rake
+++ b/lib/tasks/import_terms.rake
@@ -17,8 +17,9 @@ namespace :import do
       english_name = split_name[0]
       japanese_name = split_name[1]
       n += 1
-      term = Term.find_or_create_by(english_name: english_name, japanese_name: japanese_name)
-      puts "#{name_text} saved! #{n}" if term.save
+      term = Term.find_or_create_by!(english_name: english_name, japanese_name: japanese_name) do |term|
+        puts "#{term.english_name} saved! #{n}"
+      end
     end
 
     definitions = document.xpath("//dd")
@@ -27,7 +28,7 @@ namespace :import do
       puts "#{definition.text} #{q}"
       definition = definition.text
       term = Term.find(q)
-      term.update(definition: definition)
+      term.update!(definition: definition)
       puts "#{definition} saved! #{q}" if term.save
       q += 1
     end

--- a/spec/features/index_spec.rb
+++ b/spec/features/index_spec.rb
@@ -17,7 +17,8 @@ describe "React homepage testing", :type => :feature, js: true do
 
     within "#heroSumoWiki" do
       expect(page).to have_content("Learn More About Everything Sumo")  
-      expect(page).to have_content("Use our Sumo Wiki to learn more about the rules, history, and vocab of Sumo.")  
+      expect(page).to have_content("Use the SumoWiki to learn more about the rules, history, and vocabulary of Sumo.")
+      expect(page).to have_link("SumoWiki", :href => "/terms")
       expect(page).to have_content("Featured Term")
       expect(page).to have_content(@term.english_name)
       expect(page).to have_content(@term.japanese_name)

--- a/spec/features/navbar_spec.rb
+++ b/spec/features/navbar_spec.rb
@@ -7,6 +7,7 @@ describe "React About testing", :type => :feature, js: true do
       expect(page).to have_content("SumoCity")
       expect(page).to have_link("About")
       expect(page).to have_link("Home")
+      expect(page).to have_link("Wiki")
       expect(page).to have_css("#navbar-sumoLogo")
     end
   end

--- a/spec/features/wiki_spec.rb
+++ b/spec/features/wiki_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'SumoWiki page', :type => :feature, js: true do
+  it "displays the name of all the terms with their english name, japanese name, and definition" do
+    @term_1 = Term.create!(english_name: "Kimetaoshi", japanese_name: "極め倒し", definition: "Immobilizing the opponent's...")
+    @term_2 = Term.create!(english_name: "Mono-ii", japanese_name: "物言い", definition: "The discussion held by the shimpan...")
+    @term_3 = Term.create!(english_name: "Tsukebito", japanese_name: "付け人", definition: "A rikishi in the lower divisions...")
+
+    visit '/terms'
+
+    within '.banner' do
+      expect(page).to have_content("SumoWiki")
+    end
+
+    within "#term-#{@term_1.id}" do
+      expect(page).to have_content(@term_1.english_name)
+      expect(page).to have_content(@term_1.japanese_name)
+      expect(page).to have_content(@term_1.definition)
+    end
+
+    within "#term-#{@term_2.id}" do
+      expect(page).to have_content(@term_2.english_name)
+      expect(page).to have_content(@term_2.japanese_name)
+      expect(page).to have_content(@term_2.definition)
+    end
+
+    within "#term-#{@term_3.id}" do
+      expect(page).to have_content(@term_3.english_name)
+      expect(page).to have_content(@term_3.japanese_name)
+      expect(page).to have_content(@term_3.definition)
+    end
+
+  end
+end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -2,15 +2,17 @@ require 'rails_helper'
 
 describe Term do
   describe 'validations' do
-    it { should validate_presence_of(:english_name) }
-    it { should validate_presence_of(:japanese_name) }
-    it { should validate_presence_of(:definition) }
+    it { should validate_presence_of(:english_name).on(:create) }
+    it { should validate_presence_of(:english_name).on(:update) }
+    it { should validate_presence_of(:japanese_name).on(:create) }
+    it { should validate_presence_of(:japanese_name).on(:update) }
+    it { should validate_presence_of(:definition).on(:update) }
+    it { should_not validate_presence_of(:definition).on(:create) }
   end
 
   describe "before_action (capitalize and gsub parenthesis)" do
     it 'should update names for a new record' do
-      @term = Term.new(english_name: 'kimetaoshi', japanese_name: '(極め倒し)', definition: "immobilizing the opponent's...")
-      @term.valid?
+      @term = Term.create(english_name: 'kimetaoshi', japanese_name: '(極め倒し)', definition: "immobilizing the opponent's...")
       expect(@term.english_name).to  eq('Kimetaoshi') # Name has been capitalized
       expect(@term.japanese_name).to  eq('極め倒し') # Parenthesis have been removed
       expect(@term.definition).to  eq("Immobilizing the opponent's...") # Definition has been capitalized


### PR DESCRIPTION
# PR Documentation

## Fixes #31 

## Type of change
- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Add SumoWiki page and css styles to display all the Terms in alphabetical order
- Update raketask to import terms due to issues with adding the shoulda matcher validations
- Update Term model validations and before_validation action to properly capitalize terms upon creation
- Add comments to CSS to help differentiate CSS sections
- Add banner component to be displayed at the top of specific webpages

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes

## Other
- The heroku database will need reset and the raketask run again