### PR TITLE
58 Add About page banner

### DIFF
--- a/app/javascript/components/layout/About.js
+++ b/app/javascript/components/layout/About.js
@@ -4,7 +4,6 @@ class About extends React.Component {
   render() {
     return (
       <section className="about">
-        <h1>About SumoCity</h1>
         <p>Sumo city is your homepage for all things Sumo!</p>
         <p>Includes info on Sumos and the Stables they train in.</p>
       </section>

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -1,1 +1,2 @@
+<%= react_component 'layout/Banner', { text: "About" } %>
 <%= react_component "layout/About" %>

--- a/spec/features/about_spec.rb
+++ b/spec/features/about_spec.rb
@@ -3,9 +3,15 @@ require 'rails_helper'
 describe "React About testing", :type => :feature, js: true do
   it 'can check the About page for content' do
     visit('/about')
-    expect(page).to have_content("About SumoCity")
-    expect(page).to have_content("Sumo city is your homepage for all things Sumo")
-    expect(page).to have_content("Includes info on Sumos and the Stables they train in.")
-    expect(page).not_to have_content("The place where Sumos train is called a Stable.")
+    
+    within ".banner" do
+      expect(page).to have_content("About")
+    end
+
+    within ".about" do
+      expect(page).to have_content("Sumo city is your homepage for all things Sumo")
+      expect(page).to have_content("Includes info on Sumos and the Stables they train in.")
+      expect(page).not_to have_content("The place where Sumos train is called a Stable.")
+    end
   end
 end


### PR DESCRIPTION
# PR Documentation

## Fixes #58 

## Type of change
- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Add the banner component to the about page to display the about text
  - Remove the h1 from the about component since the banner now displays that text

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [ ] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes

## Other