### PR TITLE
Update mapbox center to be over Tokyo Japan

### DIFF
--- a/app/javascript/components/layout/map/Map.js
+++ b/app/javascript/components/layout/map/Map.js
@@ -11,8 +11,8 @@ class Map extends React.Component {
     this.map = new mapboxgl.Map({
       container: this.mapContainer,
       style: 'mapbox://styles/mapbox/streets-v11',
-      center: [-104.9966, 39.7508],
-      zoom: 19
+      center: [139.8394, 35.6528], // starting position [lng, lat]
+      zoom: 6
     });
   }
 


### PR DESCRIPTION
# PR Documentation

## Fixes #66 

## Type of change
- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Center the mapbox over Tokyo, Japan

## How Has This Been Tested?
- [ ] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [ ] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes

## Other
- Travis CI suddenly broke, likely due to a chrome update, and so the CI tests will fail but they pass locally and the app works fine in development. I opened another issue (#69 ) to fix the CI integration.