### PR TITLE
74 Set capybara and travis.ci back to chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-dist: trusty
 addons:
-  firefox: latest
+  chrome: stable
   postgresql: "9.6"
 language: ruby
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ services:
 script:
   - bundle exec rake
 before_script:
-  # Since travis has no display
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   # For assets such as images
   - RAILS_ENV=test ./bin/rails assets:precompile
   - psql -c 'create database sumo_city_test;' -U postgres

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The Capybara javascript driver has been set as Chrome with Selenium instead of R
 - Rspec
 - Capybara
 - Selenium
+- Headless chromedriver
 - Webpacker
 - Simplecov
 - shoulda-matchers

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,34 +31,36 @@ require 'capybara/dsl'
 # https://www.reddit.com/r/ruby/comments/8d6vdb/capybara_rails_chromeheadless_on_travis/
 require "selenium/webdriver"
 
-# Capybara.register_driver :chrome do |app|
-#   Capybara::Selenium::Driver.new(app, browser: :chrome)
-# end
-
-# Capybara.register_driver :headless_chrome do |app|
-#   options = Selenium::WebDriver::Chrome::Options.new
-
-#   options.add_argument('--headless')
-#   options.add_argument('--no-sandbox')
-#   options.add_argument('--disable-popup-blocking')
-#   options.add_argument('--window-size=1366,768')
-
-#   driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
-
-#   driver
-# end
-
-# Capybara.javascript_driver = :headless_chrome
-
-Capybara.register_driver :selenium do |app|
-
-  custom_profile = Selenium::WebDriver::Firefox::Profile.new
-
-  # Turn off the super annoying popup!
-  custom_profile["network.http.prompt-temp-redirect"] = false
-
-  Capybara::Selenium::Driver.new(app, :browser => :firefox, :profile => custom_profile)
+# CHROME SETUP:
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
 end
+
+Capybara.register_driver :headless_chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-popup-blocking')
+  options.add_argument('--window-size=1366,768')
+
+  driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+
+  driver
+end
+
+Capybara.javascript_driver = :headless_chrome
+
+# FIREFOX SETUP:
+# Capybara.register_driver :selenium do |app|
+
+#   custom_profile = Selenium::WebDriver::Firefox::Profile.new
+
+#   # Turn off the super annoying popup!
+#   custom_profile["network.http.prompt-temp-redirect"] = false
+
+#   Capybara::Selenium::Driver.new(app, :browser => :firefox, :profile => custom_profile)
+# end
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.


### PR DESCRIPTION
# PR Documentation

## Fixes #74 

## Type of change
- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- put the capybara driver back to chrome 
- update the travis.yml file to remove trusty, which is what caused the issues

## How Has This Been Tested?
- [ ] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [x] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [ ] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes