### PR TITLE
89 light mapbox style

### DIFF
--- a/app/javascript/components/layout/map/Mapbox.js
+++ b/app/javascript/components/layout/map/Mapbox.js
@@ -28,7 +28,7 @@ class Mapbox extends Component {
 
     return (
       <Map
-        style="mapbox://styles/mapbox/streets-v11"
+        style="mapbox://styles/mapbox/light-v10"
         containerStyle={{
           height: '85.5vh',
           width: '100vw'

--- a/spec/features/explorer_spec.rb
+++ b/spec/features/explorer_spec.rb
@@ -7,5 +7,8 @@ describe "React Explorer testing", :type => :feature, js: true do
     expect(current_path).to eq('/explorer')
 
     expect(page).to have_css(".mapboxgl-map")
+    expect(page).to have_css(".mapboxgl-control-container")
+    # Check for stylesheet script
+    expect(page).to have_selector(:css, 'script', visible: false, minimum: 1)
   end
 end


### PR DESCRIPTION
# PR Documentation

## Fixes #89 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Switch the theme of the Mapbox to light to make the colored dots pop more!
  - Add tests for mapbox controls and for the mapbox css script tag

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes

## Other
- Looks great!