### PR TITLE
94 homepage links

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Baloo+Thambi+2:wght@700;800&family=Poppins&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Baloo+Thambi+2:wght@700;800&family=Poppins:wght@400;700&display=swap');
 @import './mixins';
 @import './breakpoints';
 
@@ -120,6 +120,10 @@ ul {
   
   h3, h4 {
     text-align: center;
+  }
+  
+  a {
+    font-weight: 800;
   }
 }
 

--- a/app/javascript/components/layout/homepage/HeroStableExplorer.js
+++ b/app/javascript/components/layout/homepage/HeroStableExplorer.js
@@ -10,9 +10,8 @@ class HeroStableExplorer extends React.Component {
             <Mapbox geojson_features={this.props.geojson_features} className="homepageMap"/>
           </section>
           <section className="heroText">
-            <h1>Stable Explorer</h1>
-            <p>The place where Sumos train is called a Stable.</p>
-            <p>Use the interactive Stable Explorer to learn more about the stables of all your favorite sumo wrestlers.</p>
+            <h1>SumoCity Explorer</h1>
+            <p>Use the interactive <a href="/explorer">SumoCity Explorer</a> to learn more about the stables of all your favorite sumo wrestlers.</p>
           </section>
       </div>
     )

--- a/spec/features/index_spec.rb
+++ b/spec/features/index_spec.rb
@@ -8,9 +8,9 @@ describe "React homepage testing", :type => :feature, js: true do
     expect(page.title).to have_content("SumoCity")
 
     within "#heroStableExplorer" do     
-      expect(page).to have_content("Stable Explorer")
-      expect(page).to have_content("The place where Sumos train is called a Stable.")
-      expect(page).to have_content("Use the interactive Stable Explorer to learn more about the stables of all your favorite sumo wrestlers.")
+      expect(page).to have_content("SumoCity Explorer")
+      expect(page).to have_content("Use the interactive SumoCity Explorer to learn more about the stables of all your favorite sumo wrestlers.")
+      expect(page).to have_link("SumoCity Explorer", :href => "/explorer")
 
       within ".heroMap" do
         expect(page).to have_css(".mapboxgl-map")


### PR DESCRIPTION
# PR Documentation

## Fixes #94 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Add a link to the SumoCity Explorer on the homepage `heroStableExplorer` component.

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes