### PR TITLE
112 Update mobile navbar display to use bubble 

### DIFF
--- a/app/javascript/components/layout/Navbar.js
+++ b/app/javascript/components/layout/Navbar.js
@@ -1,6 +1,6 @@
 import React from "react"
 import sumoLogo from "../images/SumoLogo"
-import { slide as Menu } from 'react-burger-menu'
+import { bubble as Menu } from 'react-burger-menu'
 
 class Navbar extends React.Component {
   showSettings(event) {


### PR DESCRIPTION
# PR Documentation

## Fixes #112 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Update mobile navbar display to use `bubble` style instead of `slide` because it kind of looks like a sumos belly and is more sumo like

## How Has This Been Tested?
- [ ] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [ ] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [ ] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes

## Other
- How do I test this?