### PR TITLE
111 Add Stable Index and Show pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'simplecov'
   gem 'pry'
+  gem 'factory_bot_rails'
+  gem 'launchy'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,11 @@ GEM
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     execjs (2.7.0)
+    factory_bot (5.2.0)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.2.0)
+      factory_bot (~> 5.2.0)
+      railties (>= 4.2.0)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -95,6 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    launchy (2.5.0)
+      addressable (~> 2.7)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -249,7 +256,9 @@ DEPENDENCIES
   byebug
   capybara
   dotenv-rails
+  factory_bot_rails
   jbuilder (~> 2.7)
+  launchy
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The Capybara javascript driver has been set as Chrome with Selenium instead of R
 - Webpacker
 - Simplecov
 - shoulda-matchers
+- factory_bot
+- launchy
 
 ### Extensions
 - SASS

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -254,3 +254,14 @@ Note: Beware of modifying this element as it can break the animations - you shou
   text-align: center;
   background-color: var(--light-color-two);
 }
+
+/* stables */
+.stable {
+  text-align: center;
+  padding: 1rem;
+}
+
+/* Map */
+.custom-marker:hover {
+  cursor: pointer;
+}

--- a/app/controllers/stables_controller.rb
+++ b/app/controllers/stables_controller.rb
@@ -1,0 +1,32 @@
+class StablesController < ApplicationController
+  
+  def index
+    @stables = Stable.all
+  end
+
+  def show
+    @stable = Stable.find(params[:id])
+    @stables = Stable.all
+    @geojson_features = Array.new
+    
+      @stables.each do |stable|  
+      @geojson_features << {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [stable.lon, stable.lat]
+        },
+        properties: {
+          title: stable.title,
+          color: stable.hexcolor
+        }
+      }
+    end
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @geojson_features }  # respond with the created JSON object
+    end
+  end
+
+end

--- a/app/javascript/components/layout/Navbar.js
+++ b/app/javascript/components/layout/Navbar.js
@@ -18,6 +18,7 @@ class Navbar extends React.Component {
             <a id="explorer" className="menu-item" href="/explorer">Explorer</a>
             <a id="wiki" className="menu-item" href="/terms">Wiki</a>
             <a id="about" className="menu-item" href="/about">About</a>
+            <a id="stables" className="menu-item" href="/stables">Stables</a>
           </Menu>
         </div>
 
@@ -37,6 +38,9 @@ class Navbar extends React.Component {
             </li>
             <li>
               <a href='/about'>About</a>
+            </li>
+            <li>
+              <a href='/stables'>Stables</a>
             </li>
           </ul>
         </div>

--- a/app/javascript/components/layout/map/Mapbox.js
+++ b/app/javascript/components/layout/map/Mapbox.js
@@ -27,6 +27,7 @@ class Mapbox extends React.Component {
               "borderRadius": "50%",
               "backgroundColor": stable.hexcolor
             }}
+            className="custom-marker"
             onClick={() => {
               this.setSelectedMarker(stable)
             }} />
@@ -51,6 +52,15 @@ class Mapbox extends React.Component {
       selectedMarker: null
     });
   };
+
+  checkForMarker = () => {
+    if (this.props.selectedMarker) {
+      this.setSelectedMarker(this.props.selectedMarker)
+      this.closePopup()
+    } else {
+      {this.state.selectedMarker === null}
+    }
+  }
 
   
   render() {
@@ -77,6 +87,7 @@ class Mapbox extends React.Component {
         maxZoom={18}
         viewportChangeMethod={"flyTo"}
         onClick={this.closePopup}
+        onLoad={this.checkForMarker}
         > 
         {this.loadStables()}
         {this.state.selectedMarker !== null ? (
@@ -102,6 +113,7 @@ class Mapbox extends React.Component {
             <p>Founded: {this.state.selectedMarker.founded}</p>
             <p>Ichimon: {this.state.selectedMarker.ichimon}</p>
             <p>Website: {this.state.selectedMarker.website}</p>
+            <p><a href={"/stables/" + this.state.selectedMarker.id}>More Info</a></p>
           </Popup>
         ) : null}
         <Source id='stables' type='geojson' data={mapbox_geojson_data} />
@@ -121,11 +133,13 @@ class Mapbox extends React.Component {
   }
 }
 
+
 Mapbox.propTypes = {
   geojson_features: PropTypes.array,
   stables: PropTypes.array,
   height: PropTypes.string,
-  width: PropTypes.string
+  width: PropTypes.string,
+  selectedMarker: PropTypes.object
 };
 
 export default Mapbox

--- a/app/javascript/components/layout/stables/Stable.js
+++ b/app/javascript/components/layout/stables/Stable.js
@@ -1,0 +1,58 @@
+import React from "react"
+import Mapbox from "../map/Mapbox"
+import PropTypes, { object } from "prop-types"
+import 'mapbox-gl/dist/mapbox-gl.css';
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+class Stable extends React.Component {
+  render() {
+
+    const stable = this.props.selectedMarker;
+
+    return (
+      <div className="hero">
+          <div className="heroText">
+            <div id={'stable-' + stable.id} className="stable">
+              <hr className={"colorbar-" + stable.hexcolor} style={{
+                "display": "block",
+                "height": "1px",
+                "border": "0",
+                "borderTop": "5px solid",
+                "borderColor": stable.hexcolor,
+                "margin": "1em 0",
+                "padding": "0",
+              }}></hr>
+              <h3>Address: {stable.address}</h3>
+              <h3>{stable.address_jp}</h3>
+              <p>Website: <a href={stable.website}>{stable.website}</a></p>
+              <p>Phone: {stable.phone}</p>
+              <p>Ichimon: {stable.ichimon}</p>
+              <p>Founded: {stable.founded}</p>
+              <p>Closest Stations: {stable.closest_stations}</p>
+              <p>Other Info: {capitalizeFirstLetter(stable.other_info)}</p>
+            </div>
+          </div>
+          <div className="stableMap">
+            <Mapbox geojson_features={this.props.geojson_features} 
+                    stables={this.props.stables} 
+                    height={this.props.height} 
+                    width={this.props.width} 
+                    selectedMarker={this.props.selectedMarker} 
+                    className="homepageMap"/>
+          </div>
+      </div>
+    )
+  }
+}
+
+Stable.propTypes = {
+  geojson_features: PropTypes.array,
+  stables: PropTypes.array,
+  selectedMarker: object
+}
+
+export default Stable
+

--- a/app/views/stables/index.html.erb
+++ b/app/views/stables/index.html.erb
@@ -1,0 +1,9 @@
+<%= react_component 'layout/Banner', { text: "Stables" } %>
+<% @stables.each do |stable| %>
+  <div class="stable" id="stables-<%=stable.id%>">
+    <h2><%= stable.title %> Sumo Stable</h2>
+    <p><%= stable.address %></p>
+    <p><a href="<%= stable.website %>" ><%= stable.website %><a></p>
+    <h3><a href="/stables/<%=stable.id%>" >More Info<a></h3>
+  </div>
+<% end %>

--- a/app/views/stables/show.html.erb
+++ b/app/views/stables/show.html.erb
@@ -1,2 +1,3 @@
+<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.css' rel='stylesheet' />
 <%= react_component 'layout/Banner', { text: @stable.title + " Sumo Stable" } %>
 <%= react_component 'layout/stables/Stable', { geojson_features: @geojson_features, stables: @stables, height: "100%", width: "100%", selectedMarker: @stable } %>

--- a/app/views/stables/show.html.erb
+++ b/app/views/stables/show.html.erb
@@ -1,0 +1,2 @@
+<%= react_component 'layout/Banner', { text: @stable.title + " Sumo Stable" } %>
+<%= react_component 'layout/stables/Stable', { geojson_features: @geojson_features, stables: @stables, height: "100%", width: "100%", selectedMarker: @stable } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,7 @@ Rails.application.routes.draw do
   get '/terms', to: 'terms#index'
   get '/explorer', to: 'explorer#index'
 
+  get  '/stables', to: 'stables#index'
+  get  '/stables/:id', to: 'stables#show'
+
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :stable do
+    title {"Test-beya"}
+    ichimon {"Test-ichimon"}
+    founded {"2020"}
+    address {"123 test address"}
+    address_jp {"123 試験住所、市、州、日本"}
+    phone {"0-123456-789"}
+    closest_stations {"Test Station, Test Stop"}
+    website {"wwww.teststablewebsite.com"}
+    hexcolor {"#1107bd"}
+    description {"It was a pleasure to burn. It was a special pleasure to see things eaten, to see things blackened and changed."}
+    lon {9.5555}
+    lat {139.8888}
+    other_info {"With his symbolic helmet numbered 451 on his solid head, and his eyes all orange flame with the thought of what came next, he flicked the igniter and the house jumped up in a gorging fire that burned the evening sky red and yellow and black. He strode in a swarm of fireflies."}
+  end
+
+  factory :term do
+    english_name {"Test-Term"}
+    japanese_name {"試験期間"}
+    definition {"It was not the wife; it was the children, groaned the prisoner. God help me, I would not have them ashamed of their father. My God! What an exposure! What can I do? Sherlock Holmes sat down beside him on the couch and patted him kindly on the shoulder."}
+  end
+end

--- a/spec/features/explorer_spec.rb
+++ b/spec/features/explorer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe "React Explorer testing", :type => :feature, js: true do
-  it 'can check the About page for content' do
+  it 'can check the Explorer page for content' do
     visit('/')
     click_link('Explorer')
     expect(current_path).to eq('/explorer')

--- a/spec/features/navbar_spec.rb
+++ b/spec/features/navbar_spec.rb
@@ -19,6 +19,7 @@ describe "React Navbar testing", :type => :feature, js: true do
         expect(page).to have_link("Home")
         expect(page).to have_link("Wiki")
         expect(page).to have_link("Explorer")
+        expect(page).to have_link("Stables")
       end
     end
   end
@@ -39,6 +40,7 @@ describe "React Navbar testing", :type => :feature, js: true do
       expect(page).to have_link("Home", visible: false)
       expect(page).to have_link("Wiki", visible: false)
       expect(page).to have_link("Explorer", visible: false)
+      expect(page).to have_link("Stables", visible: false)
     end
   end
 end

--- a/spec/features/stables/stable_index_spec.rb
+++ b/spec/features/stables/stable_index_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe "Stable index page testing", :type => :feature, js: true do
+  it "can check the stables index page for information on all the stables" do
+    @stable_1 = create(:stable)
+    @stable_2 = create(:stable, 
+      title: "Fake-beya",
+      ichimon: "Fake-ichimon",
+      founded: "2021",
+      address: "234 fake address",
+      address_jp: "234 試験住所、市、州、日本",
+      phone: "0-987654-321",
+      closest_stations: "Fake Station, Fake Stop",
+      website: "www.fakestablewebsite.com",
+      hexcolor: "#669295",
+      description: "Hark! in the courtyard and down the rocky way the roll of heavy wheels, the crack of whips, and the chorus of the Szgany as they pass into the distance.",
+      lon: 39.5555,
+      lat: 139.8888,
+      other_info: "I am alone in the castle with those awful women. Faugh! Mina is a woman, and there is nought in common. They are devils of the Pit!"
+    )
+
+    visit("/")
+    click_link("Stables")
+
+    expect(current_path).to eq("/stables")
+
+    visit("/stables")
+
+    within(".banner") do
+      expect(page).to have_content("Stables")
+    end
+      
+    within("#stables-#{@stable_1.id}") do
+      expect(page).to have_content(@stable_1.title)
+      expect(page).to have_content(@stable_1.address)
+      expect(page).to have_link(@stable_1.website)
+      expect(page).to have_link('More Info')
+    end
+
+    within("#stables-#{@stable_2.id}") do
+      expect(page).to have_content(@stable_2.title)
+      expect(page).to have_content(@stable_2.address)
+      expect(page).to have_link(@stable_2.website)
+      expect(page).to have_link('More Info')
+    end
+  end
+end

--- a/spec/features/stables/stable_show_spec.rb
+++ b/spec/features/stables/stable_show_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe "Stable show page testing", :type => :feature, js: :true do
+  
+  it "can check an individual stable page for banner content" do
+    stable_1 = create(:stable)
+    
+    visit("/stables/#{stable_1.id}")
+    
+    within(".banner") do
+      expect(page).to have_content("#{stable_1.title} Sumo Stable")
+    end
+  end
+      
+  it "can check an individual stable page for stable content" do
+    stable_2 = create(:stable)
+    
+    visit("/stables/#{stable_2.id}")
+
+    within("#stable-#{stable_2.id}") do
+      expect(page).to have_content(stable_2.address)
+      expect(page).to have_content("Address: #{stable_2.address}")
+      expect(page).to have_content(stable_2.address_jp)
+      expect(page).to have_content("Website: #{stable_2.website}")
+      expect(page).to have_content("Phone: #{stable_2.phone}")
+      expect(page).to have_content("Ichimon: #{stable_2.ichimon}")
+      expect(page).to have_content("Founded: #{stable_2.founded}")
+      expect(page).to have_content("Closest Stations: #{stable_2.closest_stations}")
+      expect(page).to have_content("Other Info: #{stable_2.other_info}")
+      # expect(page).to have_css(".colorbar-#{stable_2.hexcolor}")
+    end
+  end
+      
+  it "can check an individual stable page for content" do
+    stable_3 = create(:stable)
+    visit("/stables/#{stable_3.id}")
+    
+    within(".stableMap") do
+      expect(page).to have_css(".mapboxgl-map")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ require 'rspec/rails'
 require 'rspec/rails'
 require 'capybara/rspec'
 require 'capybara/dsl'
+require 'support/factory_bot'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
# PR Documentation

## Fixes #111 Fixes #108 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes
- Add `/stables` routes for `index` and `show` and matching `StablesController` actions and views
- Add `Stables.js` component for rendering individual stables
- Add links to individual stable pages in the `Mapbox` components `Popups`
- Add hover effect so the cursor turns to a pointer when hovering over a Mapbox marker
- Add styles for Stables pages and component
- Add specs to test for the stables index and show page content
- Add factory_bot and launchy with configurations to help with testing
- Update documentation with factory_bot and launchy info

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [x] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes

## Other
- There is a weird glitch going on with Selenium where it generates a `Selenium::WebDriver::Error::StaleElementReferenceError`. I could not for the life of me figure out how to get this to go away but I feel it might have to do with the link to the styles in the `/stables/show.html.erb` file.