### PR TITLE
119 Add Top Sumos to Stable show pages

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -267,6 +267,13 @@ Note: Beware of modifying this element as it can break the animations - you shou
   padding: 1rem;
 }
 
+.sumo-list {
+ padding: 1rem;
+ background-color: var(--light-color-two);
+ text-align: center;
+ padding: 1rem;
+}
+
 /* Map */
 .custom-marker:hover {
   cursor: pointer;

--- a/app/controllers/stables_controller.rb
+++ b/app/controllers/stables_controller.rb
@@ -6,6 +6,7 @@ class StablesController < ApplicationController
 
   def show
     @stable = Stable.find(params[:id])
+    @sumos = @stable.sumos
     @stables = Stable.all
     @geojson_features = Array.new
     

--- a/app/javascript/components/layout/stables/Stable.js
+++ b/app/javascript/components/layout/stables/Stable.js
@@ -3,46 +3,47 @@ import Mapbox from "../map/Mapbox"
 import PropTypes, { object } from "prop-types"
 import 'mapbox-gl/dist/mapbox-gl.css';
 
-function capitalizeFirstLetter(string) {
-  return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
 class Stable extends React.Component {
+  
+  capitalizeFirstLetter = (string) => {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  }
+  
   render() {
 
     const stable = this.props.selectedMarker;
 
     return (
       <div className="hero">
-          <div className="heroText">
-            <div id={'stable-' + stable.id} className="stable">
-              <hr className={"colorbar-" + stable.hexcolor} style={{
-                "display": "block",
-                "height": "1px",
-                "border": "0",
-                "borderTop": "5px solid",
-                "borderColor": stable.hexcolor,
-                "margin": "1em 0",
-                "padding": "0",
-              }}></hr>
-              <h3>Address: {stable.address}</h3>
-              <h3>{stable.address_jp}</h3>
-              <p>Website: <a href={stable.website}>{stable.website}</a></p>
-              <p>Phone: {stable.phone}</p>
-              <p>Ichimon: {stable.ichimon}</p>
-              <p>Founded: {stable.founded}</p>
-              <p>Closest Stations: {stable.closest_stations}</p>
-              <p>Other Info: {capitalizeFirstLetter(stable.other_info)}</p>
-            </div>
+        <div className="heroText">
+          <div id={'stable-' + stable.id} className="stable">
+            <hr className={"colorbar-" + stable.hexcolor} style={{
+              "display": "block",
+              "height": "1px",
+              "border": "0",
+              "borderTop": "5px solid",
+              "borderColor": stable.hexcolor,
+              "margin": "1em 0",
+              "padding": "0",
+            }}></hr>
+            <h3>Address: {stable.address}</h3>
+            <h3>{stable.address_jp}</h3>
+            <p>Website: <a href={stable.website}>{stable.website}</a></p>
+            <p>Phone: {stable.phone}</p>
+            <p>Ichimon: {stable.ichimon}</p>
+            <p>Founded: {stable.founded}</p>
+            <p>Closest Stations: {stable.closest_stations}</p>
+            <p>Other Info: {this.capitalizeFirstLetter(stable.other_info)}</p>
           </div>
-          <div className="stableMap">
-            <Mapbox geojson_features={this.props.geojson_features} 
-                    stables={this.props.stables} 
-                    height={this.props.height} 
-                    width={this.props.width} 
-                    selectedMarker={this.props.selectedMarker} 
-                    className="homepageMap"/>
-          </div>
+        </div>
+        <div className="stableMap">
+          <Mapbox geojson_features={this.props.geojson_features} 
+                  stables={this.props.stables} 
+                  height={this.props.height} 
+                  width={this.props.width} 
+                  selectedMarker={this.props.selectedMarker} 
+                  className="homepageMap"/>
+        </div>
       </div>
     )
   }

--- a/app/javascript/components/layout/stables/StableSumos.js
+++ b/app/javascript/components/layout/stables/StableSumos.js
@@ -1,0 +1,31 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+class StableSumos extends React.Component {
+  
+  loadSumos = () => {
+    return this.props.sumos.map(sumo => {
+      return (
+        <div key={sumo.id} className="sumo" id={"sumo-" + sumo.id}>
+          <p><a href={"/sumos/" + sumo.id}>{sumo.name}</a></p>
+          <p>{sumo.rank}</p>
+        </div>
+      )
+    })
+  }
+
+  render () {
+    return (
+      <div className="sumo-list">
+        <h2>This Stables Top Sumo:</h2>
+        {this.loadSumos()} 
+      </div>
+    );
+  }
+}
+
+StableSumos.propTypes = {
+  sumos: PropTypes.array
+};
+
+export default StableSumos

--- a/app/javascript/components/layout/sumos/Sumo.js
+++ b/app/javascript/components/layout/sumos/Sumo.js
@@ -3,17 +3,15 @@ import PropTypes from "prop-types"
 class Sumo extends React.Component {
   render () {
     return (
-      <React.Fragment>
         <div className="sumo" id={"sumo-" + this.props.sumo.id}>
           <p>Ring Name(s): {this.props.sumo.ring_name}</p>
-          <p>Heya: {this.props.sumo.heya}</p>
+          <p>Heya (Stable): {this.props.sumo.heya}</p>
           <p>Rank: {this.props.sumo.rank}</p> 
           <p>Date of Birth: {this.props.sumo.date_of_birth}, {this.props.sumo.year_of_birth}</p>
           <p>Place of Birth: {this.props.sumo.place_of_birth}</p>
           <p>Height: {this.props.sumo.height}</p>
           <p>Weight: {this.props.sumo.weight}</p>
         </div>
-      </React.Fragment>
     );
   }
 }

--- a/app/views/stables/show.html.erb
+++ b/app/views/stables/show.html.erb
@@ -1,3 +1,8 @@
 <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.css' rel='stylesheet' />
 <%= react_component 'layout/Banner', { text: @stable.title + " Sumo Stable" } %>
-<%= react_component 'layout/stables/Stable', { geojson_features: @geojson_features, stables: @stables, height: "100%", width: "100%", selectedMarker: @stable } %>
+<%= react_component 'layout/stables/Stable', { geojson_features: @geojson_features, 
+                                              stables: @stables, 
+                                              height: "100%", 
+                                              width: "100%", 
+                                              selectedMarker: @stable } %>
+<%= react_component 'layout/stables/StableSumos', { sumos: @sumos } %>

--- a/spec/features/stables/stable_show_spec.rb
+++ b/spec/features/stables/stable_show_spec.rb
@@ -27,7 +27,7 @@ describe "Stable show page testing", :type => :feature, js: :true do
       expect(page).to have_content("Founded: #{stable_2.founded}")
       expect(page).to have_content("Closest Stations: #{stable_2.closest_stations}")
       expect(page).to have_content("Other Info: #{stable_2.other_info}")
-      # expect(page).to have_css(".colorbar-#{stable_2.hexcolor}")
+      # expect(page).to have_css(".colorbar-#{stable_2.hexcolor}") // Can't find this element for some reason!?
     end
   end
       
@@ -37,6 +37,41 @@ describe "Stable show page testing", :type => :feature, js: :true do
     
     within(".stableMap") do
       expect(page).to have_css(".mapboxgl-map")
+    end
+  end
+
+  it "can check for a stables sumos" do
+    stable_4 = create(:stable)
+    sumo_1 = create(:sumo, stable_id: stable_4.id)
+    sumo_2 = create( :sumo, 
+      name: "Fakesumo",
+      heya: "Test-beya",
+      full_name: "Fake Sumo",
+      ring_name: "Fakesumo Ringname",
+      rank: "Yokozuna",
+      date_of_birth: "April 21",
+      year_of_birth: "1984",
+      place_of_birth: "Hokkaido",
+      height: "180.0cm",
+      weight: "140.0kg",
+      favorite_techniques: "oshi",
+      stable_id: stable_4.id)
+
+    visit("/stables/#{stable_4.id}")
+    
+    within ".sumo-list" do
+      expect(page).to have_css(".sumo")
+
+      within "#sumo-#{sumo_1.id}" do
+        expect(page).to have_link(sumo_1.name)
+        expect(page).to have_content(sumo_1.rank)
+      end
+
+      within "#sumo-#{sumo_2.id}" do
+        expect(page).to have_link(sumo_2.name)
+        expect(page).to have_content(sumo_2.rank)
+      end
+      
     end
   end
 end


### PR DESCRIPTION
# PR Documentation

## Fixes #119 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Add a list of top sumos to the stable show pages
  - Add `@sumo` var to `StablesController` to find a stables stumos
  - Add `StableSumos` react component to display a stables top sumos
  - Add tests
- Some miscellaneous white space and indent fixes

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes

## Other
- I decided not to add them to the explorer cards for the time being. We can always add them later if wanted.