### PR TITLE
124 Responsive Sumo Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ These deprecation warnings can be silenced by appending the `RUBYOPT='-W:no-depr
  ## Contributions
 Interested in contributiong to SumoCity? Go ahead and open a PR!
 
-###### BabsLabs Software
+###### BabsLabs Software 2020

--- a/app/javascript/components/layout/stables/StableSumos.js
+++ b/app/javascript/components/layout/stables/StableSumos.js
@@ -7,8 +7,8 @@ class StableSumos extends React.Component {
     return this.props.sumos.map(sumo => {
       return (
         <div key={sumo.id} className="sumo" id={"sumo-" + sumo.id}>
-          <p><a href={"/sumos/" + sumo.id}>{sumo.name}</a></p>
-          <p>{sumo.rank}</p>
+          <h3><a href={"/sumos/" + sumo.id}>{sumo.name}</a></h3>
+          <p>Rank: {sumo.rank}</p>
         </div>
       )
     })
@@ -17,7 +17,7 @@ class StableSumos extends React.Component {
   render () {
     return (
       <div className="sumo-list">
-        <h2>This Stables Top Sumo:</h2>
+        <h2>{this.props.stableName}'s Top Sumo:</h2>
         {this.loadSumos()} 
       </div>
     );
@@ -25,7 +25,8 @@ class StableSumos extends React.Component {
 }
 
 StableSumos.propTypes = {
-  sumos: PropTypes.array
+  sumos: PropTypes.array,
+  stableName: PropTypes.string
 };
 
 export default StableSumos

--- a/app/views/stables/show.html.erb
+++ b/app/views/stables/show.html.erb
@@ -5,4 +5,4 @@
                                               height: "100%", 
                                               width: "100%", 
                                               selectedMarker: @stable } %>
-<%= react_component 'layout/stables/StableSumos', { sumos: @sumos } %>
+<%= react_component 'layout/stables/StableSumos', { sumos: @sumos, stableName: @stable.title } %>

--- a/spec/features/stables/stable_show_spec.rb
+++ b/spec/features/stables/stable_show_spec.rb
@@ -60,16 +60,17 @@ describe "Stable show page testing", :type => :feature, js: :true do
     visit("/stables/#{stable_4.id}")
     
     within ".sumo-list" do
+      expect(page).to have_content("#{stable_4.title}'s Top Sumo:")
       expect(page).to have_css(".sumo")
 
       within "#sumo-#{sumo_1.id}" do
         expect(page).to have_link(sumo_1.name)
-        expect(page).to have_content(sumo_1.rank)
+        expect(page).to have_content("Rank: #{sumo_1.rank}")
       end
 
       within "#sumo-#{sumo_2.id}" do
         expect(page).to have_link(sumo_2.name)
-        expect(page).to have_content(sumo_2.rank)
+        expect(page).to have_content("Rank: #{sumo_2.rank}")
       end
       
     end


### PR DESCRIPTION
# PR Documentation

## Fixes #124 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Make the top sumo list title responsive to use the stable name (on stable show pages) 

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [x] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes