### PR TITLE
123 render top sumo

### DIFF
--- a/app/views/stables/show.html.erb
+++ b/app/views/stables/show.html.erb
@@ -5,4 +5,6 @@
                                               height: "100%", 
                                               width: "100%", 
                                               selectedMarker: @stable } %>
-<%= react_component 'layout/stables/StableSumos', { sumos: @sumos, stableName: @stable.title } %>
+<% if @sumos.length > 0 %>
+  <%= react_component 'layout/stables/StableSumos', { sumos: @sumos, stableName: @stable.title } %>
+<% end %>

--- a/spec/features/stables/stable_show_spec.rb
+++ b/spec/features/stables/stable_show_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "Stable show page testing", :type => :feature, js: :true do
   
-  it "can check an individual stable page for banner content" do
+  it "can check an individual stable page for banner content", js: :true do
     stable_1 = create(:stable)
     
     visit("/stables/#{stable_1.id}")
@@ -12,7 +12,7 @@ describe "Stable show page testing", :type => :feature, js: :true do
     end
   end
       
-  it "can check an individual stable page for stable content" do
+  it "can check an individual stable page for stable content", js: :true do
     stable_2 = create(:stable)
     
     visit("/stables/#{stable_2.id}")
@@ -31,7 +31,7 @@ describe "Stable show page testing", :type => :feature, js: :true do
     end
   end
       
-  it "can check an individual stable page for content" do
+  it "can check an individual stable page for content", js: :true do
     stable_3 = create(:stable)
     visit("/stables/#{stable_3.id}")
     
@@ -40,7 +40,7 @@ describe "Stable show page testing", :type => :feature, js: :true do
     end
   end
 
-  it "can check for a stables sumos" do
+  it "can check for a stables sumos if they have top sumo", js: :true do
     stable_4 = create(:stable)
     sumo_1 = create(:sumo, stable_id: stable_4.id)
     sumo_2 = create( :sumo, 
@@ -74,5 +74,13 @@ describe "Stable show page testing", :type => :feature, js: :true do
       end
       
     end
+  end
+  
+  it "it doesn;t show a stables top sumo section if they don't have top sumo", js: :true do
+    stable_5 = create(:stable)
+
+    visit("/stables/#{stable_5.id}")
+    
+    expect(page).to have_no_css(".sumo_list")
   end
 end


### PR DESCRIPTION
# PR Documentation

## Fixes #123 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Add conditional rendering to only show the list of top sumo on a stable show page if that stable has top ranked sumo
- Add test for the previous

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [ ] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes