### PR TITLE
139 Add AWS .env instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Welcome to SumoCity! SumoCity is designed to keep track of everything Sumo! Curr
 ### Environment Variables
 You need the following mapbox variables configured in your `.env` file
 * `MAPBOX_ACCESS_TOKEN = "your_map_box_token`
+* `AWS_ACCESS_KEY_ID = "your_aws_access_key`
+* `AWS_SECRET_ACCESS_KEY = "your_aws_secret_access_key`
 
 ## Testing
 Testing is currently setup and done with Rspec, Capybara, and Selenium. All tests are continuously integrated with TravisCI.


### PR DESCRIPTION
# PR Documentation

## Fixes #139 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change **IS** a documentation update

## Summary of changes
- Add AWS .env instructions to the readme to improve setup instructions

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [ ] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [x] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [ ] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes