### PR TITLE
Rename fadeout to fade-in to better reflect behavior

### DIFF
--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -40,7 +40,7 @@
    }
 }
 
-// Fadeout effect
-@mixin fadeout {
+// Fade-in effect
+@mixin fade-in {
   transition: color 0.3s;
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -75,7 +75,7 @@ ul {
   a:hover {
     color: var(--light-color);
 
-    @include fadeout;
+    @include fade-in;
   }
 
   a:active {


### PR DESCRIPTION
# PR Documentation

## Fixes #145 

## Type of change
- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Rename `fadeout` scss mixin to `fade-in` to better reflect behavior

## How Has This Been Tested?
- [ ] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [ ] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes