### PR TITLE
152 Update Sumo profile_photo to be passed into Sumo.js component 

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -243,6 +243,12 @@ html, body {
   }
 }
 
+.hero-image {
+  display: flex;
+  align-content: center;
+  justify-content: center;
+}
+
 #heroSumoWiki {
   background-color: var(--light-color-two);
 }
@@ -303,14 +309,10 @@ html, body {
   cursor: pointer;
 }
 
-/* Sumo card images */
-// Note: The card borders are styled in `sumos/show.html.erb` so the border color can be passed in
+/* Sumo profile_photo images (aka - the cards) */
 .card {
   max-height: 60vh;
   margin: 20px;
-}
-
-.sumo-show {
-  align-items: center;
-  justify-items: center;
+  max-width: 40vw;
+  background-color: var(--light-color-two);
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -310,7 +310,7 @@ html, body {
 }
 
 /* Sumo profile_photo images (aka - the cards) */
-.card {
+.profile-photo {
   max-height: 60vh;
   margin: 20px;
   max-width: 40vw;

--- a/app/controllers/sumos_controller.rb
+++ b/app/controllers/sumos_controller.rb
@@ -5,6 +5,5 @@ class SumosController < ApplicationController
   
   def show
     @sumo = Sumo.find(params[:id])
-    @stable = @sumo.stable
   end
 end

--- a/app/javascript/components/layout/sumos/Sumo.js
+++ b/app/javascript/components/layout/sumos/Sumo.js
@@ -1,9 +1,28 @@
 import React from "react"
 import PropTypes from "prop-types"
+import CustomSumoLogo from "../../images/CustomSumoLogo"
+
 class Sumo extends React.Component {
+
+  CheckForProfilePhoto() {
+    const profile_photo = this.props.profile_photo
+    if (profile_photo) {
+      return (
+        <img src={this.props.profile_photo} alt={this.props.sumo.name + "profile photo"} className="card" style={{ "border": "20px solid" + this.props.stable.hexcolor }} />
+      )
+    }
+    return (
+      <img src={CustomSumoLogo} alt="palceholder profile photo" className="card" style={{ "border": "20px solid" + this.props.stable.hexcolor }} />
+    )
+  }
+
   render () {
     return (
-        <div className="hero-text sumo" id={"sumo-" + this.props.sumo.id}>
+      <div className="hero">
+        <div className="hero-image">
+          {this.CheckForProfilePhoto()}
+        </div>
+      <div className="hero-text" id={"sumo-" + this.props.sumo.id}>
           <h3>{this.props.sumo.name}'s Stats</h3>
           <p>Ring Name(s): {this.props.sumo.ring_name}</p>
           <p>Heya (Stable): <a href={"/stables/" + this.props.stable.id}>{this.props.stable.title}</a></p>
@@ -13,12 +32,15 @@ class Sumo extends React.Component {
           <p>Height: {this.props.sumo.height}</p>
           <p>Weight: {this.props.sumo.weight}</p>
         </div>
+      </div>
     );
   }
 }
 
 Sumo.propTypes = {
   sumo: PropTypes.object,
-  stable: PropTypes.object
+  stable: PropTypes.object,
+  profile_photo: PropTypes.string
 };
+
 export default Sumo

--- a/app/javascript/components/layout/sumos/Sumo.js
+++ b/app/javascript/components/layout/sumos/Sumo.js
@@ -8,11 +8,11 @@ class Sumo extends React.Component {
     const profile_photo = this.props.profile_photo
     if (profile_photo) {
       return (
-        <img src={this.props.profile_photo} alt={this.props.sumo.name + "profile photo"} className="card" style={{ "border": "20px solid" + this.props.stable.hexcolor }} />
+        <img src={this.props.profile_photo} alt={this.props.sumo.name + "profile photo"} className="profile-photo" style={{ "border": "20px solid" + this.props.stable.hexcolor }} />
       )
     }
     return (
-      <img src={CustomSumoLogo} alt="palceholder profile photo" className="card" style={{ "border": "20px solid" + this.props.stable.hexcolor }} />
+      <img src={CustomSumoLogo} alt="palceholder profile photo" className="profile-photo" style={{ "border": "20px solid" + this.props.stable.hexcolor }} />
     )
   }
 

--- a/app/views/sumos/show.html.erb
+++ b/app/views/sumos/show.html.erb
@@ -1,5 +1,8 @@
 <%= react_component 'layout/Banner', { text: @sumo.name } %>
-<div class="hero sumo-show" >
-  <%= image_tag(@sumo.profile_photo, style: "border: 20px solid #{@sumo.stable.hexcolor}", class: "card") if @sumo.profile_photo.attached? %>
-  <%= react_component 'layout/sumos/Sumo', { sumo: @sumo, stable: @stable } %>
-</div>
+  
+<% if @sumo.profile_photo.attached? %>
+  <% url = url_for(@sumo.profile_photo) %>
+<% else %>
+  <% url = nil %>
+<% end %>
+<%= react_component 'layout/sumos/Sumo', { sumo: @sumo, stable: @sumo.stable, profile_photo: url } %>

--- a/spec/features/sumos/sumo_show_spec.rb
+++ b/spec/features/sumos/sumo_show_spec.rb
@@ -38,9 +38,8 @@ describe "Sumo show page testing", :type => :feature, js: :true do
     visit("/sumos/#{sumo_3.id}")
     
     expect(page).to have_css(".hero")
-    expect(page).to have_css(".sumo-show")
+    expect(page).to have_css(".hero-image")
     
-    # Will need to find out how to best test this. Do I need a mock?
-    # expect(page).to have_css(".card")
+    expect(page).to have_css(".card")
   end
 end

--- a/spec/features/sumos/sumo_show_spec.rb
+++ b/spec/features/sumos/sumo_show_spec.rb
@@ -40,6 +40,6 @@ describe "Sumo show page testing", :type => :feature, js: :true do
     expect(page).to have_css(".hero")
     expect(page).to have_css(".hero-image")
     
-    expect(page).to have_css(".card")
+    expect(page).to have_css(".profile-photo")
   end
 end


### PR DESCRIPTION
# PR Documentation

## Fixes #152 Fixes #143 

## Type of change
- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Update the Sumo profile photo to be passed into and handled by the React component instead of being rendered in the `/sumos/show.html.erb`
  - This was done so all views could be rendered with React
- Update `sumos_controller` to remove un-needed `@stable` instance variable as it is now just called as `@sumo.stable` in the view.
- Add a default logo to be rendered if no profile_photo exists
- Add a check in both `/sumos/show.html.erb` and in `Sumo.js`
- Add tests for new default css

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes