### PR TITLE
159 Hopefully fix Mapbox map bug

### DIFF
--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -1,13 +1,9 @@
 class IndexController < ApplicationController
   def index
-    @sumo = Sumo.all.sample(1).first
-    until @sumo.profile_photo.attached? 
-      @sumo = Sumo.all.sample(1).first
-      return @sumo
-    end
-
+    @sumo = Sumo.joins(:profile_photo_attachment).sample
+    
     @term = Term.all.sample(1).first
-   
+    
     @stables = Stable.all
     @geojson_features = Array.new
     

--- a/app/javascript/components/layout/map/Mapbox.js
+++ b/app/javascript/components/layout/map/Mapbox.js
@@ -11,12 +11,11 @@ class Mapbox extends React.Component {
         longitude: 139.8394,
         zoom: 8
       },
-      stables: this.props.stables,
       selectedMarker: null
     }
   
   loadStables = () => {
-    return this.state.stables.map(stable => {
+    return this.props.stables.map(stable => {
       return (
         <Marker
           key={stable.title}


### PR DESCRIPTION
# PR Documentation

## Fixes #159 

## Type of change
- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Update the IndexController query to only find Sumo with profile_photos to use a joins table which is much more performant, avoids a loop, and always returns a record with a profile_photo.
- Update the Mapbox map to use the stables passed in as props to generate the custom markers instead of storing them in state and then iterating over that. This should be more efficient and avoid `.map` errors present in Issue #159 

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [ ] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes