### PR TITLE
164 Fix Geojson bug where stable labels weren't appearing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,10 +17,14 @@ class ApplicationController < ActionController::Base
       }
     end
 
-    respond_to do |format|
-      format.html
-      format.json { render json: geojson_features }  # respond with the created JSON object
-    end
+    mapbox_geojson_data = {
+      type: 'FeatureCollection',
+      features: geojson_features
+    }
+
+    json_mapbox_data = mapbox_geojson_data.to_json
+
+    parsed_data = JSON.parse(json_mapbox_data)
   end
 
 end

--- a/app/javascript/components/layout/homepage/HeroExplorer.js
+++ b/app/javascript/components/layout/homepage/HeroExplorer.js
@@ -20,7 +20,7 @@ class HeroExplorer extends React.Component {
 }
 
 HeroExplorer.propTypes = {
-  geojson_features: PropTypes.array,
+  geojson_features: PropTypes.object,
   stables: PropTypes.array
 }
 

--- a/app/javascript/components/layout/map/Mapbox.js
+++ b/app/javascript/components/layout/map/Mapbox.js
@@ -61,13 +61,8 @@ class Mapbox extends React.Component {
       {this.state.selectedMarker === null}
     }
   }
-
   
   render() {
-    const mapbox_geojson_data = {
-      type: 'FeatureCollection',
-      features: this.props.geojson_features
-    };
 
     return (
       <MapGL
@@ -116,7 +111,7 @@ class Mapbox extends React.Component {
             <p><a href={"/stables/" + this.state.selectedMarker.id}>More Info</a></p>
           </Popup>
         ) : null}
-        <Source id='stables' type='geojson' data={mapbox_geojson_data} />
+        <Source id='stables' type='geojson' data={this.props.geojson_features} />
         <Layer
           id='stables'
           type='symbol'
@@ -135,7 +130,7 @@ class Mapbox extends React.Component {
 
 
 Mapbox.propTypes = {
-  geojson_features: PropTypes.array,
+  geojson_features: PropTypes.object,
   stables: PropTypes.array,
   height: PropTypes.string,
   width: PropTypes.string,

--- a/app/javascript/components/layout/stables/Stable.js
+++ b/app/javascript/components/layout/stables/Stable.js
@@ -50,7 +50,7 @@ class Stable extends React.Component {
 }
 
 Stable.propTypes = {
-  geojson_features: PropTypes.array,
+  geojson_features: PropTypes.object,
   stables: PropTypes.array,
   selectedMarker: object
 }


### PR DESCRIPTION
# PR Documentation

## Fixes #164 

## Type of change
- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Fix Geojson bug where stable labels weren't appearing by updating the `make_stables_geojson` method in `application_controller` to return the full and properly formatted geojson object for the `Mapbox.js` component.

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes